### PR TITLE
Fix tilemap size issue

### DIFF
--- a/src/scenes/PlayScene.ts
+++ b/src/scenes/PlayScene.ts
@@ -16,10 +16,15 @@ class PlayScene extends Phaser.Scene {
 	}
 
 	create() {
+		const width = 25;
+		const height = 19;
+		const defaultTileIndex = 0;
+		const data = Array.from({ length: height }, () => Array(width).fill(defaultTileIndex));
+
 		this.tilemap = this.make.tilemap({
-			data: [],
-			width: 25,
-			height: 19,
+			data: data,
+			width: width,
+			height: height,
 			tileWidth: 32,
 			tileHeight: 32,
 		});


### PR DESCRIPTION
Related to #6

Update `src/scenes/PlayScene.ts` to correctly set tilemap width and height.

* Initialize the `data` property of the `this.make.tilemap` method with a 2D array filled with a default tile index (0).
* Set the `width` and `height` parameters of the `this.make.tilemap` method to 25 and 19 respectively.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nl9/issues/6?shareId=89505c41-74c9-4f90-8447-b9069d435929).