### PR TITLE
Correctly use multiple tileset images

### DIFF
--- a/src/scenes/PlayScene.ts
+++ b/src/scenes/PlayScene.ts
@@ -31,8 +31,25 @@ class PlayScene extends Phaser.Scene {
 			tileHeight: 32,
 		});
 
-		const unfilledTileset = this.tilemap.addTilesetImage("unfilled", undefined, 32, 32, 0, 0, 1);
-		const filledTileset = this.tilemap.addTilesetImage("filled", undefined, 32, 32, 0, 0, 2);
+		const unfilledTileset = this.tilemap.addTilesetImage(
+			"unfilled",
+			undefined,
+			32,
+			32,
+			0,
+			0,
+			1,
+		);
+		this.tilemap.addTilesetImage;
+		const filledTileset = this.tilemap.addTilesetImage(
+			"filled",
+			undefined,
+			32,
+			32,
+			0,
+			0,
+			2,
+		);
 
 		this.tilemap.tilesets.forEach((tileset) => console.log(tileset));
 		if (unfilledTileset === null || filledTileset === null) {
@@ -46,7 +63,13 @@ class PlayScene extends Phaser.Scene {
 		);
 		for (let y = 0; y < this.tilemap.height; y++) {
 			for (let x = 0; x < this.tilemap.width; x++) {
-				this.layer.putTileAt(unfilledTileset.firstgid, x, y);
+				this.layer.putTileAt(
+					Math.random() > 0.5
+						? filledTileset.firstgid
+						: unfilledTileset.firstgid,
+					x,
+					y,
+				);
 			}
 		}
 	}

--- a/src/scenes/PlayScene.ts
+++ b/src/scenes/PlayScene.ts
@@ -31,8 +31,8 @@ class PlayScene extends Phaser.Scene {
 			tileHeight: 32,
 		});
 
-		const unfilledTileset = this.tilemap.addTilesetImage("unfilled");
-		const filledTileset = this.tilemap.addTilesetImage("filled");
+		const unfilledTileset = this.tilemap.addTilesetImage("unfilled", undefined, 32, 32, 0, 0, 1);
+		const filledTileset = this.tilemap.addTilesetImage("filled", undefined, 32, 32, 0, 0, 2);
 
 		this.tilemap.tilesets.forEach((tileset) => console.log(tileset));
 		if (unfilledTileset === null || filledTileset === null) {


### PR DESCRIPTION
Related to #8

Update `src/scenes/PlayScene.ts` to correctly reference multiple tileset images.

* Set unique `firstgid` for each tileset in the `create` method.
* Modify `addTilesetImage` method to include `firstgid` for each tileset.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nl9/issues/8?shareId=5f99c67d-ae94-4c29-a685-665d1d8ebbb3).