### PR TITLE
Refactor map code

### DIFF
--- a/src/scenes/PlayScene.ts
+++ b/src/scenes/PlayScene.ts
@@ -1,77 +1,21 @@
 import Phaser from "phaser";
 import { generateSolidColorTexture } from "../utils/TextureGenerator";
+import MapManager from "../utils/MapManager";
 
 class PlayScene extends Phaser.Scene {
-	private tilemap: Phaser.Tilemaps.Tilemap;
-	private tileset: Phaser.Tilemaps.Tileset;
-	private layer: Phaser.Tilemaps.DynamicTilemapLayer;
+	private mapManager: MapManager;
 
 	constructor() {
 		super({ key: "PlayScene" });
+		this.mapManager = new MapManager(this);
 	}
 
 	preload() {
-		generateSolidColorTexture(this, "unfilled", 0xff0000, 32, 32);
-		generateSolidColorTexture(this, "filled", 0xf0ff00, 32, 32);
+		this.mapManager.preload();
 	}
 
 	create() {
-		const width = 25;
-		const height = 19;
-		const defaultTileIndex = 0;
-		const data = Array.from({ length: height }, () =>
-			Array(width).fill(defaultTileIndex),
-		);
-
-		this.tilemap = this.make.tilemap({
-			data: data,
-			width: width,
-			height: height,
-			tileWidth: 32,
-			tileHeight: 32,
-		});
-
-		const unfilledTileset = this.tilemap.addTilesetImage(
-			"unfilled",
-			undefined,
-			32,
-			32,
-			0,
-			0,
-			1,
-		);
-		this.tilemap.addTilesetImage;
-		const filledTileset = this.tilemap.addTilesetImage(
-			"filled",
-			undefined,
-			32,
-			32,
-			0,
-			0,
-			2,
-		);
-
-		this.tilemap.tilesets.forEach((tileset) => console.log(tileset));
-		if (unfilledTileset === null || filledTileset === null) {
-			throw new Error("Unable to add tileset image.");
-		}
-		this.layer = this.tilemap.createLayer(
-			0,
-			[unfilledTileset, filledTileset],
-			0,
-			0,
-		);
-		for (let y = 0; y < this.tilemap.height; y++) {
-			for (let x = 0; x < this.tilemap.width; x++) {
-				this.layer.putTileAt(
-					Math.random() > 0.5
-						? filledTileset.firstgid
-						: unfilledTileset.firstgid,
-					x,
-					y,
-				);
-			}
-		}
+		this.mapManager.create();
 	}
 
 	update() {

--- a/src/utils/MapManager.ts
+++ b/src/utils/MapManager.ts
@@ -2,78 +2,77 @@ import Phaser from "phaser";
 import { generateSolidColorTexture } from "./TextureGenerator";
 
 class MapManager {
-  private tilemap: Phaser.Tilemaps.Tilemap;
-  private tileset: Phaser.Tilemaps.Tileset;
-  private layer: Phaser.Tilemaps.DynamicTilemapLayer;
-  private scene: Phaser.Scene;
+	private tilemap: Phaser.Tilemaps.Tilemap;
+	private layer: Phaser.Tilemaps.TilemapLayer;
+	private scene: Phaser.Scene;
 
-  constructor(scene: Phaser.Scene) {
-    this.scene = scene;
-  }
+	constructor(scene: Phaser.Scene) {
+		this.scene = scene;
+	}
 
-  preload() {
-    generateSolidColorTexture(this.scene, "unfilled", 0xff0000, 32, 32);
-    generateSolidColorTexture(this.scene, "filled", 0xf0ff00, 32, 32);
-  }
+	preload() {
+		generateSolidColorTexture(this.scene, "unfilled", 0xff0000, 32, 32);
+		generateSolidColorTexture(this.scene, "filled", 0xf0ff00, 32, 32);
+	}
 
-  create() {
-    const width = 25;
-    const height = 19;
-    const defaultTileIndex = 0;
-    const data = Array.from({ length: height }, () =>
-      Array(width).fill(defaultTileIndex),
-    );
+	create() {
+		const width = 25;
+		const height = 19;
+		const defaultTileIndex = 0;
+		const data = Array.from({ length: height }, () =>
+			Array(width).fill(defaultTileIndex),
+		);
 
-    this.tilemap = this.scene.make.tilemap({
-      data: data,
-      width: width,
-      height: height,
-      tileWidth: 32,
-      tileHeight: 32,
-    });
+		this.tilemap = this.scene.make.tilemap({
+			data: data,
+			width: width,
+			height: height,
+			tileWidth: 32,
+			tileHeight: 32,
+		});
 
-    const unfilledTileset = this.tilemap.addTilesetImage(
-      "unfilled",
-      undefined,
-      32,
-      32,
-      0,
-      0,
-      1,
-    );
-    this.tilemap.addTilesetImage;
-    const filledTileset = this.tilemap.addTilesetImage(
-      "filled",
-      undefined,
-      32,
-      32,
-      0,
-      0,
-      2,
-    );
+		const unfilledTileset = this.tilemap.addTilesetImage(
+			"unfilled",
+			undefined,
+			32,
+			32,
+			0,
+			0,
+			1,
+		);
+		this.tilemap.addTilesetImage;
+		const filledTileset = this.tilemap.addTilesetImage(
+			"filled",
+			undefined,
+			32,
+			32,
+			0,
+			0,
+			2,
+		);
 
-    this.tilemap.tilesets.forEach((tileset) => console.log(tileset));
-    if (unfilledTileset === null || filledTileset === null) {
-      throw new Error("Unable to add tileset image.");
-    }
-    this.layer = this.tilemap.createLayer(
-      0,
-      [unfilledTileset, filledTileset],
-      0,
-      0,
-    );
-    for (let y = 0; y < this.tilemap.height; y++) {
-      for (let x = 0; x < this.tilemap.width; x++) {
-        this.layer.putTileAt(
-          Math.random() > 0.5
-            ? filledTileset.firstgid
-            : unfilledTileset.firstgid,
-          x,
-          y,
-        );
-      }
-    }
-  }
+		this.tilemap.tilesets.forEach((tileset) => console.log(tileset));
+		if (unfilledTileset === null || filledTileset === null) {
+			throw new Error("Unable to add tileset image.");
+		}
+		this.layer = this.tilemap.createLayer(
+			0,
+			[unfilledTileset, filledTileset],
+			0,
+			0,
+		);
+		for (let y = 0; y < this.tilemap.height; y++) {
+			for (let x = 0; x < this.tilemap.width; x++) {
+				this.layer.putTileAt(
+					Math.random() > 0.5
+						? filledTileset.firstgid
+						: unfilledTileset.firstgid,
+					x,
+					y,
+				);
+			}
+		}
+	}
 }
 
 export default MapManager;

--- a/src/utils/MapManager.ts
+++ b/src/utils/MapManager.ts
@@ -1,0 +1,79 @@
+import Phaser from "phaser";
+import { generateSolidColorTexture } from "./TextureGenerator";
+
+class MapManager {
+  private tilemap: Phaser.Tilemaps.Tilemap;
+  private tileset: Phaser.Tilemaps.Tileset;
+  private layer: Phaser.Tilemaps.DynamicTilemapLayer;
+  private scene: Phaser.Scene;
+
+  constructor(scene: Phaser.Scene) {
+    this.scene = scene;
+  }
+
+  preload() {
+    generateSolidColorTexture(this.scene, "unfilled", 0xff0000, 32, 32);
+    generateSolidColorTexture(this.scene, "filled", 0xf0ff00, 32, 32);
+  }
+
+  create() {
+    const width = 25;
+    const height = 19;
+    const defaultTileIndex = 0;
+    const data = Array.from({ length: height }, () =>
+      Array(width).fill(defaultTileIndex),
+    );
+
+    this.tilemap = this.scene.make.tilemap({
+      data: data,
+      width: width,
+      height: height,
+      tileWidth: 32,
+      tileHeight: 32,
+    });
+
+    const unfilledTileset = this.tilemap.addTilesetImage(
+      "unfilled",
+      undefined,
+      32,
+      32,
+      0,
+      0,
+      1,
+    );
+    this.tilemap.addTilesetImage;
+    const filledTileset = this.tilemap.addTilesetImage(
+      "filled",
+      undefined,
+      32,
+      32,
+      0,
+      0,
+      2,
+    );
+
+    this.tilemap.tilesets.forEach((tileset) => console.log(tileset));
+    if (unfilledTileset === null || filledTileset === null) {
+      throw new Error("Unable to add tileset image.");
+    }
+    this.layer = this.tilemap.createLayer(
+      0,
+      [unfilledTileset, filledTileset],
+      0,
+      0,
+    );
+    for (let y = 0; y < this.tilemap.height; y++) {
+      for (let x = 0; x < this.tilemap.width; x++) {
+        this.layer.putTileAt(
+          Math.random() > 0.5
+            ? filledTileset.firstgid
+            : unfilledTileset.firstgid,
+          x,
+          y,
+        );
+      }
+    }
+  }
+}
+
+export default MapManager;


### PR DESCRIPTION
Related to #10

Refactor map/tileset code into a separate class.

* Add a new file `src/utils/MapManager.ts` with a `MapManager` class to handle map/tileset code.
* Move `tilemap`, `tileset`, and `layer` properties to the `MapManager` class.
* Add `preload` and `create` methods to the `MapManager` class to handle texture loading and tilemap initialization.
* Update `src/scenes/PlayScene.ts` to import and use the `MapManager` class.
* Remove map/tileset code from the `PlayScene` class and update `preload` and `create` methods to call `mapManager` methods.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nl9/issues/10?shareId=5d58593a-6ca8-44b1-8a17-d785fce1132e).