### PR TITLE
Add player

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -6,7 +6,14 @@ const config: Phaser.Types.Core.GameConfig = {
   width: 800,
   height: 600,
   scene: [PlayScene],
-  parent: 'game-container'
+  parent: 'game-container',
+  physics: {
+    default: 'arcade',
+    arcade: {
+      gravity: { y: 300 },
+      debug: false
+    }
+  }
 };
 
 const game = new Phaser.Game(config);

--- a/src/scenes/PlayScene.ts
+++ b/src/scenes/PlayScene.ts
@@ -1,6 +1,7 @@
 import Phaser from "phaser";
 import MapManager from "../utils/MapManager";
 import MapGenerator from "../utils/MapGenerator";
+import { generateSolidColorTexture } from "../utils/TextureGenerator";
 
 class PlayScene extends Phaser.Scene {
 	private mapManager: MapManager;
@@ -14,7 +15,7 @@ class PlayScene extends Phaser.Scene {
 
 	preload() {
 		this.mapManager.preload();
-		this.load.image("player", "path/to/player/texture.png");
+		generateSolidColorTexture(this, "player", 0x800080, 32, 32);
 	}
 
 	create() {

--- a/src/scenes/PlayScene.ts
+++ b/src/scenes/PlayScene.ts
@@ -56,7 +56,7 @@ class PlayScene extends Phaser.Scene {
 			this.player.setVelocityX(0);
 		}
 
-		if (this.cursors.up.isDown && this.player.body.touching.down) {
+		if (this.cursors.up.isDown && this.player.body?.blocked.down) {
 			this.player.setVelocityY(-330);
 		}
 	}

--- a/src/scenes/PlayScene.ts
+++ b/src/scenes/PlayScene.ts
@@ -4,6 +4,8 @@ import MapGenerator from "../utils/MapGenerator";
 
 class PlayScene extends Phaser.Scene {
 	private mapManager: MapManager;
+	private player!: Phaser.Physics.Arcade.Sprite;
+	private cursors!: Phaser.Types.Input.Keyboard.CursorKeys;
 
 	constructor() {
 		super({ key: "PlayScene" });
@@ -12,6 +14,7 @@ class PlayScene extends Phaser.Scene {
 
 	preload() {
 		this.mapManager.preload();
+		this.load.image("player", "path/to/player/texture.png");
 	}
 
 	create() {
@@ -33,10 +36,30 @@ class PlayScene extends Phaser.Scene {
 
 		const map = mapGenerator.generateMap();
 		this.mapManager.populateTilemap(map, width, height);
+
+		this.player = this.physics.add.sprite(100, 100, "player");
+		this.player.setCollideWorldBounds(true);
+		this.player.setGravityY(300);
+
+		this.cursors = this.input.keyboard.createCursorKeys();
+
+		this.physics.add.collider(this.player, this.mapManager.layer);
+
+		this.mapManager.layer.setCollisionByExclusion([-1, 0]);
 	}
 
 	update() {
-		// Update game objects here
+		if (this.cursors.left.isDown) {
+			this.player.setVelocityX(-160);
+		} else if (this.cursors.right.isDown) {
+			this.player.setVelocityX(160);
+		} else {
+			this.player.setVelocityX(0);
+		}
+
+		if (this.cursors.up.isDown && this.player.body.touching.down) {
+			this.player.setVelocityY(-330);
+		}
 	}
 }
 

--- a/src/scenes/PlayScene.ts
+++ b/src/scenes/PlayScene.ts
@@ -45,8 +45,6 @@ class PlayScene extends Phaser.Scene {
 		this.cursors = this.input.keyboard.createCursorKeys();
 
 		this.physics.add.collider(this.player, this.mapManager.layer);
-
-		this.mapManager.layer.setCollisionByExclusion([-1, 0]);
 	}
 
 	update() {

--- a/src/utils/MapManager.ts
+++ b/src/utils/MapManager.ts
@@ -94,6 +94,7 @@ class MapManager {
 				);
 			}
 		}
+		this.layer.setCollision(this.tilemap.tilesets[1].firstgid, true);
 	}
 }
 


### PR DESCRIPTION
Related to #14

Add a player sprite and implement player movement, jumping, gravity, and collision detection.

* **Player Sprite**
  - Add player sprite in `create` method.
  - Set player sprite to be solid purple and tile-sized.
  - Set player sprite to collide with world bounds.
  - Set player sprite gravity to 300.

* **Player Movement**
  - Add player movement with cursor keys in `update` method.
  - Set player velocity based on left and right cursor keys.

* **Player Jumping**
  - Add player jumping with up key in `update` method.
  - Set player velocity for jumping when up key is pressed and player is touching the ground.

* **Collision Detection**
  - Add collision detection with filled tiles in `create` method.
  - Configure the tilemap layer for collision on filled tiles only.

* **Additional Changes**
  - Load player texture in `preload` method.
  - Create cursor keys input in `create` method.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nl9/issues/14?shareId=1046a921-0637-4568-aca1-c8dc9a36d66a).