### PR TITLE
Correct player spawn point

### DIFF
--- a/src/scenes/PlayScene.ts
+++ b/src/scenes/PlayScene.ts
@@ -15,6 +15,15 @@ class PlayScene extends Phaser.Scene {
 	}
 
 	create() {
+		this.createMap();
+		this.createPlayer();
+	}
+
+	update() {
+		// Update game objects here
+	}
+
+	private createMap() {
 		const width = 25;
 		const height = 19;
 		const initialFillProbability = 0.45;
@@ -35,8 +44,14 @@ class PlayScene extends Phaser.Scene {
 		this.mapManager.populateTilemap(map, width, height);
 	}
 
-	update() {
-		// Update game objects here
+	private createPlayer() {
+		const nonWallSpaces = this.mapManager.getNonWallSpaces();
+		const randomIndex = Phaser.Math.Between(0, nonWallSpaces.length - 1);
+		const spawnPoint = nonWallSpaces[randomIndex];
+
+		// Create the player at the spawn point
+		const player = this.add.sprite(spawnPoint.x * 32, spawnPoint.y * 32, 'player');
+		this.physics.add.existing(player);
 	}
 }
 

--- a/src/utils/MapManager.ts
+++ b/src/utils/MapManager.ts
@@ -95,6 +95,22 @@ class MapManager {
 			}
 		}
 	}
+
+	getRandomNonWallSpace(): { x: number, y: number } {
+		const nonWallSpaces: { x: number, y: number }[] = [];
+
+		for (let y = 0; y < this.tilemap.height; y++) {
+			for (let x = 0; x < this.tilemap.width; x++) {
+				const tile = this.layer.getTileAt(x, y);
+				if (tile && tile.index === this.tilemap.tilesets[0].firstgid) {
+					nonWallSpaces.push({ x, y });
+				}
+			}
+		}
+
+		const randomIndex = Phaser.Math.Between(0, nonWallSpaces.length - 1);
+		return nonWallSpaces[randomIndex];
+	}
 }
 
 export default MapManager;


### PR DESCRIPTION
Related to #16

Correct player spawn point to ensure the player spawns only in non-wall spaces.

* Add `createPlayer` method in `PlayScene` class to handle player creation.
* Call `createPlayer` method after map generation in `create` method of `PlayScene`.
* Implement logic to find a random non-wall space for player spawn in `PlayScene`.
* Refactor map creation logic to its own method in `PlayScene`.
* Add `getRandomNonWallSpace` method in `MapManager` class to return a random non-wall coordinate.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nl9/issues/16?shareId=4f4743c7-fe1b-4249-ad2e-fc966658005d).