### PR TITLE
Fix player spawn point

### DIFF
--- a/src/scenes/PlayScene.ts
+++ b/src/scenes/PlayScene.ts
@@ -38,13 +38,18 @@ class PlayScene extends Phaser.Scene {
 		const map = mapGenerator.generateMap();
 		this.mapManager.populateTilemap(map, width, height);
 
-		this.player = this.physics.add.sprite(100, 100, "player");
-		this.player.setCollideWorldBounds(true);
-		this.player.setGravityY(300);
+		this.createPlayer(map);
 
 		this.cursors = this.input.keyboard.createCursorKeys();
 
 		this.physics.add.collider(this.player, this.mapManager.layer);
+	}
+
+	createPlayer() {
+		const { x, y } = this.mapManager.getRandomNonWallPosition(map);
+		this.player = this.physics.add.sprite(x * 32, y * 32, "player");
+		this.player.setCollideWorldBounds(true);
+		this.player.setGravityY(300);
 	}
 
 	update() {

--- a/src/scenes/PlayScene.ts
+++ b/src/scenes/PlayScene.ts
@@ -46,7 +46,7 @@ class PlayScene extends Phaser.Scene {
 	}
 
 	createPlayer() {
-		const { x, y } = this.mapManager.getRandomNonWallPosition(map);
+		const { x, y } = this.mapManager.getRandomNonWallPosition();
 		this.player = this.physics.add.sprite(x * 32, y * 32, "player");
 		this.player.setCollideWorldBounds(true);
 		this.player.setGravityY(300);

--- a/src/utils/MapManager.ts
+++ b/src/utils/MapManager.ts
@@ -97,12 +97,13 @@ class MapManager {
 		this.layer.setCollision(this.tilemap.tilesets[1].firstgid, true);
 	}
 
-	getRandomNonWallPosition(map: number[][]): { x: number, y: number } {
+	getRandomNonWallPosition(): { x: number, y: number } {
 		const nonWallPositions: { x: number, y: number }[] = [];
 
-		for (let y = 0; y < map.length; y++) {
-			for (let x = 0; x < map[y].length; x++) {
-				if (map[y][x] === 0) {
+		for (let y = 0; y < this.tilemap.height; y++) {
+			for (let x = 0; x < this.tilemap.width; x++) {
+				const tile = this.tilemap.getTileAt(x, y);
+				if (tile && tile.index === this.tilemap.tilesets[0].firstgid) {
 					nonWallPositions.push({ x, y });
 				}
 			}

--- a/src/utils/MapManager.ts
+++ b/src/utils/MapManager.ts
@@ -96,6 +96,25 @@ class MapManager {
 		}
 		this.layer.setCollision(this.tilemap.tilesets[1].firstgid, true);
 	}
+
+	getRandomNonWallPosition(map: number[][]): { x: number, y: number } {
+		const nonWallPositions: { x: number, y: number }[] = [];
+
+		for (let y = 0; y < map.length; y++) {
+			for (let x = 0; x < map[y].length; x++) {
+				if (map[y][x] === 0) {
+					nonWallPositions.push({ x, y });
+				}
+			}
+		}
+
+		if (nonWallPositions.length === 0) {
+			throw new Error("No non-wall positions available.");
+		}
+
+		const randomIndex = Math.floor(Math.random() * nonWallPositions.length);
+		return nonWallPositions[randomIndex];
+	}
 }
 
 export default MapManager;


### PR DESCRIPTION
Related to #19

Update player spawn logic to select a random location that is not a wall.

* Add `getRandomNonWallPosition` method in `src/utils/MapManager.ts` to return a random position that is not a wall.
* Refactor player creation into a `createPlayer` method in `src/scenes/PlayScene.ts`.
* Update `create` method in `src/scenes/PlayScene.ts` to call `createPlayer`.
* Use `getRandomNonWallPosition` in `createPlayer` to set the player's initial position.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nl9/issues/19?shareId=6adeaaf1-8e12-4b88-a9cb-697e1d3e8757).