### PR TITLE
Ensure wall tiles always surround the generated map

### DIFF
--- a/src/utils/MapGenerator.ts
+++ b/src/utils/MapGenerator.ts
@@ -45,7 +45,21 @@ class MapGenerator {
       }
     }
 
+    this.fillEdgesWithWalls(map);
+
     return map;
+  }
+
+  private fillEdgesWithWalls(map: number[][]): void {
+    for (let y = 0; y < this.height; y++) {
+      map[y][0] = 1;
+      map[y][this.width - 1] = 1;
+    }
+
+    for (let x = 0; x < this.width; x++) {
+      map[0][x] = 1;
+      map[this.height - 1][x] = 1;
+    }
   }
 
   private simulateStep(map: number[][]): number[][] {

--- a/src/utils/MapManager.ts
+++ b/src/utils/MapManager.ts
@@ -93,7 +93,15 @@ class MapManager {
 					y,
 				);
 			}
+			this.layer.putTileAt(this.tilemap.tilesets[1].firstgid, 0, y);
+			this.layer.putTileAt(this.tilemap.tilesets[1].firstgid, this.tilemap.width - 1, y);
 		}
+
+		for (let x = 0; x < this.tilemap.width; x++) {
+			this.layer.putTileAt(this.tilemap.tilesets[1].firstgid, x, 0);
+			this.layer.putTileAt(this.tilemap.tilesets[1].firstgid, x, this.tilemap.height - 1);
+		}
+
 		this.layer.setCollision(this.tilemap.tilesets[1].firstgid, true);
 	}
 


### PR DESCRIPTION
Related to #22

Update `initializeMap` method in `src/utils/MapGenerator.ts` to ensure outer edges are filled with wall tiles.

* Add a new private method `fillEdgesWithWalls` to fill edges with wall tiles.
* Call `fillEdgesWithWalls` method in `initializeMap` method.

Update `populateTilemap` method in `src/utils/MapManager.ts` to ensure outer edges are filled with wall tiles.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nl9/issues/22?shareId=5cd8bbcd-1fc8-41cd-a9f4-566f45917e0d).