### PR TITLE
Fix player spawn point to overlap exactly with one tile

### DIFF
--- a/src/scenes/PlayScene.ts
+++ b/src/scenes/PlayScene.ts
@@ -50,6 +50,7 @@ class PlayScene extends Phaser.Scene {
 		this.player = this.physics.add.sprite(x * 32, y * 32, "player");
 		this.player.setCollideWorldBounds(true);
 		this.player.setGravityY(300);
+		this.player.setOrigin(0.5, 0.5);
 	}
 
 	update() {

--- a/src/scenes/PlayScene.ts
+++ b/src/scenes/PlayScene.ts
@@ -47,7 +47,7 @@ class PlayScene extends Phaser.Scene {
 
 	createPlayer(map) {
 		const { x, y } = this.mapManager.getRandomNonWallPosition(map);
-		this.player = this.physics.add.sprite(x * 32, y * 32, "player");
+		this.player = this.physics.add.sprite(x * 32 + 16, y * 32 + 16, "player");
 		this.player.setCollideWorldBounds(true);
 		this.player.setGravityY(300);
 		this.player.setOrigin(0.5, 0.5);


### PR DESCRIPTION
Related to #24

Update player spawn point to align with a single tile.

* Modify `createPlayer` method in `src/scenes/PlayScene.ts` to set player position to align with a single tile.
* Add `this.player.setOrigin(0.5, 0.5)` to ensure the player sprite aligns perfectly with a single tile.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nl9/issues/24?shareId=d5c66c3c-fd56-4aa3-a8c9-aede353064f9).