### PR TITLE
Implement grappling hook mechanic

### DIFF
--- a/src/scenes/PlayScene.ts
+++ b/src/scenes/PlayScene.ts
@@ -7,6 +7,8 @@ class PlayScene extends Phaser.Scene {
 	private mapManager: MapManager;
 	private player!: Phaser.Physics.Arcade.Sprite;
 	private cursors!: Phaser.Types.Input.Keyboard.CursorKeys;
+	private grapplingHook!: Phaser.GameObjects.Graphics;
+	private shiftKey!: Phaser.Input.Keyboard.Key;
 
 	constructor() {
 		super({ key: "PlayScene" });
@@ -41,8 +43,11 @@ class PlayScene extends Phaser.Scene {
 		this.createPlayer(map);
 
 		this.cursors = this.input.keyboard.createCursorKeys();
+		this.shiftKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.SHIFT);
 
 		this.physics.add.collider(this.player, this.mapManager.layer);
+
+		this.grapplingHook = this.add.graphics({ lineStyle: { width: 2, color: 0xff0000 } });
 	}
 
 	createPlayer(map) {
@@ -54,16 +59,48 @@ class PlayScene extends Phaser.Scene {
 	}
 
 	update() {
-		if (this.cursors.left.isDown) {
-			this.player.setVelocityX(-160);
-		} else if (this.cursors.right.isDown) {
-			this.player.setVelocityX(160);
-		} else {
+		if (this.shiftKey.isDown) {
 			this.player.setVelocityX(0);
-		}
 
-		if (this.cursors.up.isDown && this.player.body?.blocked.down) {
-			this.player.setVelocityY(-330);
+			if (this.cursors.up.isDown) {
+				this.player.setVelocityY(-160);
+			} else if (this.cursors.down.isDown) {
+				this.player.setVelocityY(160);
+			} else {
+				this.player.setVelocityY(0);
+			}
+
+			this.drawGrapplingHook();
+		} else {
+			if (this.cursors.left.isDown) {
+				this.player.setVelocityX(-160);
+			} else if (this.cursors.right.isDown) {
+				this.player.setVelocityX(160);
+			} else {
+				this.player.setVelocityX(0);
+			}
+
+			if (this.cursors.up.isDown && this.player.body?.blocked.down) {
+				this.player.setVelocityY(-330);
+			}
+
+			this.grapplingHook.clear();
+		}
+	}
+
+	drawGrapplingHook() {
+		const playerX = this.player.x;
+		const playerY = this.player.y;
+		const tileX = Math.floor(playerX / 32);
+		const tileY = Math.floor(playerY / 32);
+
+		for (let y = tileY; y >= 0; y--) {
+			const tile = this.mapManager.layer.getTileAt(tileX, y);
+			if (tile && tile.index !== -1) {
+				this.grapplingHook.clear();
+				this.grapplingHook.lineBetween(playerX, playerY, playerX, y * 32);
+				break;
+			}
 		}
 	}
 }

--- a/src/scenes/PlayScene.ts
+++ b/src/scenes/PlayScene.ts
@@ -98,7 +98,7 @@ class PlayScene extends Phaser.Scene {
 			const tile = this.mapManager.layer.getTileAt(tileX, y);
 			if (tile && tile.index === this.mapManager.layer.tileset[1].firstgid) {
 				this.grapplingHook.clear();
-				this.grapplingHook.lineBetween(playerX, playerY, playerX, y * 32);
+				this.grapplingHook.lineBetween(playerX, playerY, playerX, (y + 1) * 32);
 				break;
 			}
 		}

--- a/src/scenes/PlayScene.ts
+++ b/src/scenes/PlayScene.ts
@@ -96,7 +96,7 @@ class PlayScene extends Phaser.Scene {
 
 		for (let y = tileY; y >= 0; y--) {
 			const tile = this.mapManager.layer.getTileAt(tileX, y);
-			if (tile && tile.index !== -1) {
+			if (tile && tile.index === this.mapManager.layer.tileset[1].firstgid) {
 				this.grapplingHook.clear();
 				this.grapplingHook.lineBetween(playerX, playerY, playerX, y * 32);
 				break;


### PR DESCRIPTION
Related to #26

Implement grappling hook mechanic in `PlayScene.ts`.

* Add `grapplingHook` property to store the grappling hook line.
* Add `shiftKey` property to store the shift key input.
* Modify `create` method to initialize the `shiftKey` property and create the `grapplingHook` graphics object.
* Modify `update` method to handle the grappling hook mechanic:
  * Deploy grappling hook when the shift key is held down.
  * Allow vertical movement using the up/down cursor keys while the shift key is held down.
  * Constrain horizontal movement while the shift key is held down.
  * Detach grappling hook when the shift key is released.
* Add `drawGrapplingHook` method to draw the grappling hook line from the player's position to the wall tile directly above.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nl9/issues/26?shareId=84a58708-df17-4918-bb4d-2fe03b2d49bd).