### PR TITLE
Implement physics stepper mechanic

### DIFF
--- a/src/scenes/PlayScene.ts
+++ b/src/scenes/PlayScene.ts
@@ -9,10 +9,16 @@ class PlayScene extends Phaser.Scene {
 	private cursors!: Phaser.Types.Input.Keyboard.CursorKeys;
 	private grapplingHook!: Phaser.GameObjects.Graphics;
 	private shiftKey!: Phaser.Input.Keyboard.Key;
+	private zKey!: Phaser.Input.Keyboard.Key;
+	private movementMode: number;
+	private acceleration: number;
+	private modeText!: Phaser.GameObjects.Text;
 
 	constructor() {
 		super({ key: "PlayScene" });
 		this.mapManager = new MapManager(this);
+		this.movementMode = 1;
+		this.acceleration = 300;
 	}
 
 	preload() {
@@ -44,10 +50,15 @@ class PlayScene extends Phaser.Scene {
 
 		this.cursors = this.input.keyboard.createCursorKeys();
 		this.shiftKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.SHIFT);
+		this.zKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.Z);
 
 		this.physics.add.collider(this.player, this.mapManager.layer);
 
 		this.grapplingHook = this.add.graphics({ lineStyle: { width: 2, color: 0xff0000 } });
+
+		this.zKey.on('down', this.toggleMovementMode, this);
+
+		this.modeText = this.add.text(10, 10, 'Mode: 1', { fontSize: '16px', fill: '#fff' });
 	}
 
 	createPlayer(map) {
@@ -72,12 +83,22 @@ class PlayScene extends Phaser.Scene {
 
 			this.drawGrapplingHook();
 		} else {
-			if (this.cursors.left.isDown) {
-				this.player.setVelocityX(-160);
-			} else if (this.cursors.right.isDown) {
-				this.player.setVelocityX(160);
-			} else {
-				this.player.setVelocityX(0);
+			if (this.movementMode === 1) {
+				if (this.cursors.left.isDown) {
+					this.player.setVelocityX(-160);
+				} else if (this.cursors.right.isDown) {
+					this.player.setVelocityX(160);
+				} else {
+					this.player.setVelocityX(0);
+				}
+			} else if (this.movementMode === 2) {
+				if (this.cursors.left.isDown) {
+					this.player.setAccelerationX(-this.acceleration);
+				} else if (this.cursors.right.isDown) {
+					this.player.setAccelerationX(this.acceleration);
+				} else {
+					this.player.setAccelerationX(0);
+				}
 			}
 
 			if (this.cursors.up.isDown && this.player.body?.blocked.down) {
@@ -86,6 +107,11 @@ class PlayScene extends Phaser.Scene {
 
 			this.grapplingHook.clear();
 		}
+	}
+
+	toggleMovementMode() {
+		this.movementMode = this.movementMode === 1 ? 2 : 1;
+		this.modeText.setText(`Mode: ${this.movementMode}`);
 	}
 
 	drawGrapplingHook() {


### PR DESCRIPTION
Related to #28

Implement physics stepper mechanic to cycle between two modes of player movement.

* Add `movementMode` and `acceleration` properties to track the current player movement mode and adjustable acceleration value.
* Add `zKey` property to handle the 'z' key press for changing player movement modes.
* Add `modeText` property to display the current player movement mode on the screen.
* Initialize `movementMode`, `acceleration`, and `zKey` in the `create` method.
* Add `toggleMovementMode` method to switch between movement modes and update the displayed mode text.
* Update the `update` method to handle player movement based on the current `movementMode` and apply acceleration in Mode 2.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nl9/issues/28?shareId=bba50218-0f70-44df-9d00-490149731dfd).