### PR TITLE
Refactor player spawn method to not use map parameter

### DIFF
--- a/src/scenes/PlayScene.ts
+++ b/src/scenes/PlayScene.ts
@@ -46,7 +46,8 @@ class PlayScene extends Phaser.Scene {
 		const map = mapGenerator.generateMap();
 		this.mapManager.populateTilemap(map, width, height);
 
-		this.createPlayer(map);
+		const { x, y } = this.mapManager.getRandomNonWallPosition(map);
+		this.createPlayer(x, y);
 
 		this.cursors = this.input.keyboard.createCursorKeys();
 		this.shiftKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.SHIFT);
@@ -61,8 +62,7 @@ class PlayScene extends Phaser.Scene {
 		this.modeText = this.add.text(10, 10, 'Mode: 1', { fontSize: '16px', fill: '#fff' });
 	}
 
-	createPlayer(map) {
-		const { x, y } = this.mapManager.getRandomNonWallPosition(map);
+	createPlayer(x: number, y: number) {
 		this.player = this.physics.add.sprite(x * 32 + 16, y * 32 + 16, "player");
 		this.player.setCollideWorldBounds(true);
 		this.player.setGravityY(300);


### PR DESCRIPTION
Related to #33

Refactor the player spawn method to not use the map parameter.

* Modify the `createPlayer` method in `src/scenes/PlayScene.ts` to take x, y coordinates instead of the `map` parameter.
* Update the `create` method in `src/scenes/PlayScene.ts` to call `getRandomNonWallPosition` and pass the x, y coordinates to `createPlayer`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nl9/issues/33?shareId=da8f1608-5563-4946-9f12-5d1aff4bef8f).