### PR TITLE
Fix grappling hook anchoring issue

### DIFF
--- a/src/scenes/PlayScene.ts
+++ b/src/scenes/PlayScene.ts
@@ -210,13 +210,14 @@ class PlayScene extends Phaser.Scene {
 		const tileX = Math.floor(playerX / 32);
 		const tileY = Math.floor(playerY / 32);
 
+		const firstWallTileY = this.mapManager.findFirstWallTileAbove(tileX, tileY);
+		if (firstWallTileY !== null) {
+			this.grapplingHookLength = playerY - (firstWallTileY + 1) * 32;
+			this.drawGrapplingHook();
+		}
 
-		this.grapplingHookLength = (tileY + 1) * 32;
-		this.grapplingHook.clear();
-		this.grapplingHook.lineBetween(playerX, playerY, playerX, playerY - this.grapplingHookLength);
 		this.grapplingHookDeploying = false;
 		this.grapplingHookDeployed = true;
-
 	}
 
 	retractGrapplingHook() {

--- a/src/scenes/PlayScene.ts
+++ b/src/scenes/PlayScene.ts
@@ -19,6 +19,7 @@ class PlayScene extends Phaser.Scene {
 	private grapplingHookDeploying: boolean;
 	private grapplingHookRetracting: boolean;
 	private grapplingHookLength: number;
+	private grapplingHookAnchorY: number | null;
 
 	constructor() {
 		super({ key: "PlayScene" });
@@ -37,6 +38,7 @@ class PlayScene extends Phaser.Scene {
 		this.grapplingHookDeploying = false;
 		this.grapplingHookRetracting = false;
 		this.grapplingHookLength = 0;
+		this.grapplingHookAnchorY = null;
 	}
 
 	preload() {
@@ -148,11 +150,14 @@ class PlayScene extends Phaser.Scene {
 		if (this.grapplingHookDeployed) {
 			if (this.inputManager.inputs.up) {
 				this.player.setVelocityY(-160);
+				this.grapplingHookLength -= 160 / 60; // Adjust length as player moves up
 			} else if (this.inputManager.inputs.down) {
 				this.player.setVelocityY(160);
+				this.grapplingHookLength += 160 / 60; // Adjust length as player moves down
 			} else {
 				this.player.setVelocityY(0);
 			}
+			this.drawGrapplingHook();
 		}
 
 		this.updateHud();
@@ -189,16 +194,11 @@ class PlayScene extends Phaser.Scene {
 	drawGrapplingHook() {
 		const playerX = this.player.x;
 		const playerY = this.player.y;
-		const tileX = Math.floor(playerX / 32);
-		const tileY = Math.floor(playerY / 32);
 
-		for (let y = tileY; y >= 0; y--) {
-			const tile = this.mapManager.layer.getTileAt(tileX, y);
-			if (tile && tile.index === this.mapManager.layer.tileset[1].firstgid) {
-				this.grapplingHook.clear();
-				this.grapplingHook.lineBetween(playerX, playerY, playerX, (y + 1) * 32);
-				break;
-			}
+		if (this.grapplingHookAnchorY !== null) {
+			this.grapplingHook.clear();
+			this.grapplingHook.lineStyle(2, 0x00ff00, 1);
+			this.grapplingHook.lineBetween(playerX, playerY, playerX, this.grapplingHookAnchorY);
 		}
 	}
 
@@ -213,6 +213,7 @@ class PlayScene extends Phaser.Scene {
 		const firstWallTileY = this.mapManager.findFirstWallTileAbove(tileX, tileY);
 		if (firstWallTileY !== null) {
 			this.grapplingHookLength = playerY - (firstWallTileY + 1) * 32;
+			this.grapplingHookAnchorY = (firstWallTileY + 1) * 32;
 			this.drawGrapplingHook();
 		}
 
@@ -227,6 +228,7 @@ class PlayScene extends Phaser.Scene {
 		this.grapplingHook.clear();
 		this.grapplingHookRetracting = false;
 		this.grapplingHookDeployed = false;
+		this.grapplingHookAnchorY = null;
 	}
 }
 

--- a/src/scenes/PlayScene.ts
+++ b/src/scenes/PlayScene.ts
@@ -70,7 +70,7 @@ class PlayScene extends Phaser.Scene {
 		this.physics.add.collider(this.player, this.mapManager.layer);
 
 		this.grapplingHook = this.add.graphics({
-			lineStyle: { width: 2, color: 0xff0000 },
+			lineStyle: { width: 2, color: 0x00ff00 },
 		});
 
 		this.modeText = this.add.text(10, 10, "Mode: 1", {

--- a/src/utils/MapManager.ts
+++ b/src/utils/MapManager.ts
@@ -123,6 +123,16 @@ class MapManager {
 		const randomIndex = Math.floor(Math.random() * nonWallPositions.length);
 		return nonWallPositions[randomIndex];
 	}
+
+	findFirstWallTileAbove(x: number, y: number): number | null {
+		for (let i = y; i >= 0; i--) {
+			const tile = this.layer.getTileAt(x, i);
+			if (tile && tile.index === this.layer.tileset[1].firstgid) {
+				return i;
+			}
+		}
+		return null;
+	}
 }
 
 export default MapManager;


### PR DESCRIPTION
Related to #42

Modify the grappling hook deployment logic to anchor to the first wall tile directly above the player.

* **PlayScene.ts**
  - Add logic to find the first wall tile directly above the player using `findFirstWallTileAbove` method.
  - Set the grappling hook length to the distance between the player and the first wall tile.
  - Call `drawGrapplingHook` method within `deployGrapplingHook` method to visually represent the grappling hook.

* **MapManager.ts**
  - Add `findFirstWallTileAbove` method to find the first wall tile directly above a given position.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nl9/issues/42?shareId=ced466f6-2546-44bb-a8b5-ea3630cb160c).