### PR TITLE
Use a constant for Tile size

### DIFF
--- a/src/scenes/PlayScene.ts
+++ b/src/scenes/PlayScene.ts
@@ -3,6 +3,7 @@ import MapManager from "../utils/MapManager";
 import MapGenerator from "../utils/MapGenerator";
 import { generateSolidColorTexture } from "../utils/TextureGenerator";
 import InputManager from "../utils/InputManager";
+import { TILE_SIZE } from "../utils/Constants";
 
 class PlayScene extends Phaser.Scene {
 	private mapManager: MapManager;
@@ -40,7 +41,7 @@ class PlayScene extends Phaser.Scene {
 
 	preload() {
 		this.mapManager.preload();
-		generateSolidColorTexture(this, "player", 0x800080, 32, 32);
+		generateSolidColorTexture(this, "player", 0x800080, TILE_SIZE, TILE_SIZE);
 	}
 
 	create() {
@@ -80,7 +81,7 @@ class PlayScene extends Phaser.Scene {
 	}
 
 	createPlayer(x: number, y: number) {
-		this.player = this.physics.add.sprite(x * 32 + 16, y * 32 + 16, "player");
+		this.player = this.physics.add.sprite(x * TILE_SIZE + 16, y * TILE_SIZE + 16, "player");
 		this.player.setCollideWorldBounds(true);
 		this.updateHyper();
 		this.player.setOrigin(0.5, 0.5);
@@ -179,13 +180,13 @@ class PlayScene extends Phaser.Scene {
 		this.grapplingHookLength = 0;
 		const playerX = this.player.x;
 		const playerY = this.player.y;
-		const tileX = Math.floor(playerX / 32);
-		const tileY = Math.floor(playerY / 32);
+		const tileX = Math.floor(playerX / TILE_SIZE);
+		const tileY = Math.floor(playerY / TILE_SIZE);
 
 		const firstWallTileY = this.mapManager.findFirstWallTileAbove(tileX, tileY);
 		if (firstWallTileY !== null) {
-			this.grapplingHookLength = playerY - (firstWallTileY + 1) * 32;
-			this.grapplingHookAnchorY = (firstWallTileY + 1) * 32;
+			this.grapplingHookLength = playerY - (firstWallTileY + 1) * TILE_SIZE;
+			this.grapplingHookAnchorY = (firstWallTileY + 1) * TILE_SIZE;
 			this.drawGrapplingHook();
 		}
 

--- a/src/utils/Constants.ts
+++ b/src/utils/Constants.ts
@@ -1,0 +1,1 @@
+export const TILE_SIZE = 32;

--- a/src/utils/MapManager.ts
+++ b/src/utils/MapManager.ts
@@ -1,6 +1,7 @@
 import Phaser from "phaser";
 import { generateSolidColorTexture } from "./TextureGenerator";
 import MapGenerator from "./MapGenerator";
+import { TILE_SIZE } from "./Constants";
 
 class MapManager {
 	private tilemap!: Phaser.Tilemaps.Tilemap;
@@ -12,8 +13,8 @@ class MapManager {
 	}
 
 	preload() {
-		generateSolidColorTexture(this.scene, "unfilled", 0x00aa00, 32, 32);
-		generateSolidColorTexture(this.scene, "filled", 0x000000, 32, 32);
+		generateSolidColorTexture(this.scene, "unfilled", 0x00aa00, TILE_SIZE, TILE_SIZE);
+		generateSolidColorTexture(this.scene, "filled", 0x000000, TILE_SIZE, TILE_SIZE);
 	}
 
 	create() {
@@ -43,15 +44,15 @@ class MapManager {
 				data: map,
 				width: width,
 				height: height,
-				tileWidth: 32,
-				tileHeight: 32,
+				tileWidth: TILE_SIZE,
+				tileHeight: TILE_SIZE,
 			});
 
 			const unfilledTileset = this.tilemap.addTilesetImage(
 				"unfilled",
 				undefined,
-				32,
-				32,
+				TILE_SIZE,
+				TILE_SIZE,
 				0,
 				0,
 				1,
@@ -60,8 +61,8 @@ class MapManager {
 			const filledTileset = this.tilemap.addTilesetImage(
 				"filled",
 				undefined,
-				32,
-				32,
+				TILE_SIZE,
+				TILE_SIZE,
 				0,
 				0,
 				2,

--- a/src/utils/TextureGenerator.ts
+++ b/src/utils/TextureGenerator.ts
@@ -1,4 +1,5 @@
 import Phaser from 'phaser';
+import { TILE_SIZE } from './Constants';
 
 export function generateSolidColorTexture(scene: Phaser.Scene, name: string, color: number, width: number, height: number): string {
   const graphics = new Phaser.GameObjects.Graphics(scene);


### PR DESCRIPTION
Related to #46

Define a constant for the tile size and replace literal values with the constant.

* Add `TILE_SIZE` constant in `src/utils/Constants.ts` and set it to 32.
* Import `TILE_SIZE` in `src/scenes/PlayScene.ts` and replace all instances of the literal number 32 with `TILE_SIZE`.
* Import `TILE_SIZE` in `src/utils/MapManager.ts` and replace all instances of the literal number 32 with `TILE_SIZE`.
* Import `TILE_SIZE` in `src/utils/TextureGenerator.ts`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nl9/issues/46?shareId=deed2ce8-9d4b-4f7d-ba87-6a403e131fb8).